### PR TITLE
Generalize ollama naming to llm and use /api/llm route

### DIFF
--- a/src/components/Text.spec.ts
+++ b/src/components/Text.spec.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 import Text from './Text.vue'
 import Modal from './Modal.vue'
 import { filesManagerService } from '../services/filesManager'
-import { ollamaService } from '../services/ollama'
+import { llmService } from '../services/llm'
 import * as sharedFiles from '../services/sharedFiles'
 import * as sharedModel from '../services/sharedModel'
 
@@ -18,8 +18,8 @@ vi.mock('../services/filesManager', () => ({
   }
 }))
 
-vi.mock('../services/ollama', () => ({
-  ollamaService: {
+vi.mock('../services/llm', () => ({
+  llmService: {
     generate: vi.fn()
   }
 }))
@@ -130,7 +130,7 @@ describe('Text.vue', () => {
     )
   })
 
-  it('calls ollama service and applies text directly', async () => {
+  it('calls llm service and applies text directly', async () => {
     const wrapper = mount(Text, {
       global: { stubs: { teleport: true } }
     })
@@ -141,7 +141,7 @@ describe('Text.vue', () => {
     // Clear mock calls from loadFile/auto-save setup
     vi.mocked(filesManagerService.updateFileContent).mockClear()
 
-    vi.mocked(ollamaService.generate).mockResolvedValue('AI generated text')
+    vi.mocked(llmService.generate).mockResolvedValue('AI generated text')
 
     // Find "Generate" button
     const generateBtn = wrapper.findAll('button').find(b => b.text() === 'Generate')
@@ -149,7 +149,7 @@ describe('Text.vue', () => {
     
     await flushPromises()
 
-    expect(ollamaService.generate).toHaveBeenCalledWith(
+    expect(llmService.generate).toHaveBeenCalledWith(
       1,
       'llama3',
       'Initial content'

--- a/src/components/Text.vue
+++ b/src/components/Text.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted } from 'vue'
 import { filesManagerService } from '../services/filesManager'
-import { ollamaService } from '../services/ollama'
+import { llmService } from '../services/llm'
 import { useSharedFiles } from '../services/sharedFiles'
 import { useSharedModel } from '../services/sharedModel'
 import { isLoggedIn } from '../services/api'
@@ -92,7 +92,7 @@ const handleGenerate = async () => {
   if (!isLoggedIn() || !currentFileID.value) return
 
   try {
-    const result = await ollamaService.generate(
+    const result = await llmService.generate(
       currentFileID.value,
       selectedModelName.value,
       text.value
@@ -103,7 +103,7 @@ const handleGenerate = async () => {
     }
   } catch (e) {
     console.error('Error generating text:', e)
-    displayError('Error generating text with Ollama')
+    displayError('Error generating text')
   }
 }
 

--- a/src/services/llm.spec.ts
+++ b/src/services/llm.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ollamaService } from './ollama'
+import { llmService } from './llm'
 
 const API_URL = 'http://localhost:8000/api'
 
-describe('ollamaService', () => {
+describe('llmService', () => {
   let fetchSpy = vi.spyOn(window, 'fetch')
 
   beforeEach(() => {
@@ -26,10 +26,10 @@ describe('ollamaService', () => {
       json: async () => mockRes
     } as Response)
 
-    const result = await ollamaService.generate(id, model, prompt)
+    const result = await llmService.generate(id, model, prompt)
 
     expect(result).toBe('Hi there!')
-    expect(fetchSpy).toHaveBeenCalledWith(`${API_URL}/ollama/generate`, {
+    expect(fetchSpy).toHaveBeenCalledWith(`${API_URL}/llm/generate`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -42,6 +42,6 @@ describe('ollamaService', () => {
 
   it('throws error when generate fetch fails', async () => {
     fetchSpy.mockResolvedValueOnce({ ok: false } as Response)
-    await expect(ollamaService.generate(1, 'm', 'p')).rejects.toThrow('Ollama request failed')
+    await expect(llmService.generate(1, 'm', 'p')).rejects.toThrow('LLM request failed')
   })
 })

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -1,15 +1,15 @@
 import { API_URL, jsonHeaders } from './api';
 import { apiFetch } from './apiFetch';
 
-export const ollamaService = {
+export const llmService = {
     async generate(id: number, model: string, prompt: string): Promise<string> {
-        const response = await apiFetch(`${API_URL}/ollama/generate`, {
+        const response = await apiFetch(`${API_URL}/llm/generate`, {
             method: "POST",
             headers: jsonHeaders(),
             body: JSON.stringify({ id, model, prompt }),
         });
 
-        if (!response.ok) throw new Error("Ollama request failed");
+        if (!response.ok) throw new Error("LLM request failed");
         const data = await response.json();
         return data.snippet;
     },

--- a/src/services/model.spec.ts
+++ b/src/services/model.spec.ts
@@ -26,7 +26,7 @@ describe('modelService', () => {
     const result = await modelService.getModels()
 
     expect(result).toEqual(mockModels)
-    expect(fetchSpy).toHaveBeenCalledWith(`${API_URL}/ollama/models`, {
+    expect(fetchSpy).toHaveBeenCalledWith(`${API_URL}/llm/models`, {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',

--- a/src/services/model.ts
+++ b/src/services/model.ts
@@ -7,7 +7,7 @@ export interface Model {
 
 export const modelService = {
   async getModels(): Promise<Model[]> {
-    const response = await apiFetch(`${API_URL}/ollama/models`, {
+    const response = await apiFetch(`${API_URL}/llm/models`, {
       headers: jsonHeaders(),
     });
 


### PR DESCRIPTION
Follows the backend rename of /api/ollama to /api/llm. Renames the service module and all identifiers to be provider-agnostic now that the backend fronts multiple LLM providers (Ollama and/or LiteLLM).

- services/ollama.ts -> services/llm.ts; ollamaService -> llmService
- endpoints /ollama/generate and /ollama/models -> /llm/* (llm.ts, model.ts and their specs)
- Text.vue import/usage updated; error message no longer Ollama-specific