### PR TITLE
Polish UI: design token system, depth, collapsible sidebar, title

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,9 +6,15 @@ import Tree from './components/Tree.vue'
 import Text from './components/Text.vue'
 
 const isAuthenticated = ref(false)
+const isSidebarOpen = ref(true)
 
 const handleAuthExpired = () => {
   isAuthenticated.value = false
+}
+
+const toggleSidebar = () => {
+  isSidebarOpen.value = !isSidebarOpen.value
+  localStorage.setItem('sidebarOpen', String(isSidebarOpen.value))
 }
 
 onMounted(() => {
@@ -16,6 +22,11 @@ onMounted(() => {
   // whether a session is already active on load.
   if (isLoggedIn()) {
     isAuthenticated.value = true
+  }
+  // Restore the last sidebar state so it survives reloads.
+  const storedSidebar = localStorage.getItem('sidebarOpen')
+  if (storedSidebar !== null) {
+    isSidebarOpen.value = storedSidebar === 'true'
   }
   window.addEventListener('auth:expired', handleAuthExpired)
 })
@@ -31,7 +42,17 @@ const handleLoginSuccess = () => {
 
 <template>
   <div v-if="isAuthenticated" class="app-layout">
-    <aside>
+    <button
+      class="sidebar-toggle"
+      type="button"
+      @click="toggleSidebar"
+      :aria-label="isSidebarOpen ? 'Hide sidebar' : 'Show sidebar'"
+      :aria-expanded="isSidebarOpen"
+    >
+      {{ isSidebarOpen ? '«' : '☰' }}
+    </button>
+
+    <aside :class="{ collapsed: !isSidebarOpen }">
       <Tree />
     </aside>
 
@@ -57,13 +78,53 @@ aside {
   border-right: 1px solid var(--color-border);
   overflow: hidden;
   background-color: var(--color-background);
+  /* Slide out via negative margin so the tree contents don't squish while
+     animating; .app-layout's overflow:hidden clips the off-screen panel. */
+  transition: margin-left 220ms ease;
+}
+
+aside.collapsed {
+  margin-left: -300px;
+}
+
+/* Pinned toggle that stays put in both states: it sits in the tree's empty
+   title-bar corner when open, and floats over the editor when collapsed. */
+.sidebar-toggle {
+  position: fixed;
+  top: 8px;
+  left: 12px;
+  z-index: 300;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: background-color var(--transition), color var(--transition);
+}
+
+.sidebar-toggle:hover {
+  background-color: var(--color-background-mute);
+  color: var(--color-primary);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 main {
   flex: 1;
-  padding: 2rem;
+  padding: 2rem 2rem 2.5rem;
   overflow-y: auto;
-  background-color: var(--color-background-soft);
+  /* Slightly recessed canvas so the editor card reads as raised above it. */
+  background-color: var(--color-background);
 }
 
 .content-placeholder {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -38,13 +38,36 @@
   --color-primary-soft: rgba(33, 150, 243, 0.1);
   --color-danger: var(--ink-c-red);
 
-  --shadow-normal: 0 2px 10px rgba(0, 0, 0, 0.1);
-  --shadow-strong: 0 2px 10px rgba(0, 0, 0, 0.2);
-  --shadow-card: 0 4px 6px rgba(0, 0, 0, 0.1);
+  /* Layered, softer shadows read as more "expensive" than a single flat drop. */
+  --shadow-normal: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.06);
+  --shadow-strong: 0 2px 4px rgba(0, 0, 0, 0.06), 0 8px 24px rgba(0, 0, 0, 0.12);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.08);
 
   --hover-background: #e3f2fd;
   --selected-border: var(--ink-c-blue);
   --icon-color: #555;
+
+  /* --- design tokens --- */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  --transition: 160ms ease;
+  --transition-theme: 300ms ease;
+
+  --font-weight-medium: 600;
+  --font-weight-bold: 700;
+
+  /* Soft focus ring for keyboard/click focus (accessible + polished). */
+  --focus-ring: 0 0 0 3px var(--color-primary-soft);
 }
 
 body.dark-theme {
@@ -62,9 +85,9 @@ body.dark-theme {
   --color-primary-hover: var(--ink-c-blue);
   --color-primary-soft: rgba(17, 134, 227, 0.2);
 
-  --shadow-normal: 0 2px 10px rgba(0, 0, 0, 0.5);
-  --shadow-strong: 0 2px 10px rgba(0, 0, 0, 0.7);
-  --shadow-card: 0 4px 6px rgba(0, 0, 0, 0.5);
+  --shadow-normal: 0 1px 2px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.45);
+  --shadow-strong: 0 2px 4px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.6);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.5), 0 10px 30px rgba(0, 0, 0, 0.55);
 
   --hover-background: var(--ink-c-blue-deep);
   --selected-border: var(--color-primary);
@@ -84,8 +107,8 @@ body {
   color: var(--color-text);
   background: var(--color-background);
   transition:
-    color 0.5s,
-    background-color 0.5s;
+    color var(--transition-theme),
+    background-color var(--transition-theme);
   line-height: 1.6;
   font-family:
     Inter,

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -4,8 +4,9 @@ a,
 .green {
     text-decoration: none;
     color: var(--color-primary);
-    transition: 0.4s;
+    transition: background-color var(--transition);
     padding: 3px;
+    border-radius: var(--radius-sm);
 }
 
 @media (hover: hover) {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -91,8 +91,8 @@ const handleLogin = async () => {
 
 .login-card {
   background: var(--color-background-soft);
-  padding: 2rem;
-  border-radius: 8px;
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   width: 100%;
   max-width: 400px;
@@ -100,33 +100,37 @@ const handleLogin = async () => {
 
 h2 {
   text-align: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
   color: var(--color-heading);
+  font-weight: var(--font-weight-bold);
 }
 
 .form-group {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
 }
 
 label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--space-2);
   color: var(--color-text);
+  font-weight: var(--font-weight-medium);
 }
 
 input {
   width: 100%;
   padding: 0.75rem;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-background);
   color: var(--color-text);
   font-size: 1rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 input:focus {
   outline: none;
   border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
 }
 
 button {
@@ -135,15 +139,26 @@ button {
   background-color: var(--color-primary);
   color: white;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 1rem;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background-color 0.3s;
-  margin-top: 1rem;
+  transition: background-color var(--transition), transform var(--transition), box-shadow var(--transition);
+  margin-top: var(--space-4);
 }
 
-button:hover {
+button:hover:not(:disabled) {
   background-color: var(--color-primary-hover);
+  transform: translateY(-1px);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 button:disabled {
@@ -153,7 +168,7 @@ button:disabled {
 
 .error-message {
   color: var(--color-danger);
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-4);
   font-size: 0.9rem;
   text-align: center;
 }

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -24,25 +24,36 @@ const handleInput = (event: Event) => {
 <style scoped>
 .markdown-editor {
   width: 100%;
-  height: 100%;
+  /* Fill the space the editor-container gives us instead of a fixed 80vh,
+     so the page never overflows and the action buttons keep steady spacing. */
+  flex: 1;
+  min-height: 0;
+  display: flex;
 }
 
 textarea {
   width: 100%;
-  height: 80vh;
-  padding: 1rem;
+  flex: 1;
+  min-height: 240px;
+  padding: 1.25rem 1.5rem;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background-color: var(--color-background-soft);
   color: var(--color-text);
-  font-family: 'Courier New', Courier, monospace;
+  font-family: ui-monospace, 'SF Mono', 'JetBrains Mono', 'Cascadia Code',
+    Menlo, Consolas, monospace;
   font-size: 1rem;
-  line-height: 1.5;
-  resize: vertical;
+  line-height: 1.7;
+  resize: none;
+  /* Raised writing surface above the recessed canvas. */
+  box-shadow: var(--shadow-card);
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 textarea:focus {
   outline: none;
   border-color: var(--color-primary);
+  /* Keep the card elevation, add the focus ring on top. */
+  box-shadow: var(--focus-ring), var(--shadow-card);
 }
 </style>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -64,8 +64,8 @@ const handleConfirm = () => {
 
 .modal {
   background: var(--color-background);
-  padding: 24px;
-  border-radius: 8px;
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
   width: 90%;
   display: flex;
   flex-direction: column;
@@ -77,6 +77,7 @@ const handleConfirm = () => {
 h3 {
   margin: 0;
   color: var(--color-heading);
+  font-weight: var(--font-weight-bold);
 }
 
 .modal-body {
@@ -95,15 +96,26 @@ button {
   padding: 8px 16px;
   cursor: pointer;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-background-soft);
   color: var(--color-text);
-  font-weight: 500;
-  transition: all 0.2s;
+  font-weight: var(--font-weight-medium);
+  transition: background-color var(--transition), border-color var(--transition),
+    transform var(--transition), box-shadow var(--transition), filter var(--transition);
 }
 
 button:hover:not(:disabled) {
   background: var(--color-background-mute);
+  transform: translateY(-1px);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 button:disabled {
@@ -140,21 +152,23 @@ button:disabled {
 
 :deep(label) {
   font-size: 0.9rem;
-  font-weight: bold;
+  font-weight: var(--font-weight-medium);
 }
 
 :deep(input), :deep(textarea) {
   padding: 10px;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background-color: var(--color-background-soft);
   color: var(--color-text);
   font-family: inherit;
   width: 100%;
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 :deep(input:focus), :deep(textarea:focus) {
   outline: none;
   border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
 }
 </style>

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -53,21 +53,29 @@ h3 {
   margin-bottom: 0.5rem;
   font-size: 1.1rem;
   color: var(--color-heading);
+  font-weight: var(--font-weight-bold);
 }
 
 select {
   width: 100%;
   padding: 8px;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background-color: var(--color-background-soft);
   color: var(--color-text);
   font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+select:hover {
+  border-color: var(--color-border-hover);
 }
 
 select:focus {
   outline: none;
   border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
 }
 
 .error {

--- a/src/components/Text.vue
+++ b/src/components/Text.vue
@@ -141,8 +141,8 @@ onUnmounted(() => {
 <template>
   <div class="text-page">
     <div class="header">
-      <p v-if="fileName">{{ fileName }}</p>
-      <p v-else>No file selected</p>
+      <p v-if="fileName" class="file-title">{{ fileName }}</p>
+      <p v-else class="file-title empty">No file selected</p>
     </div>
 
     <div class="editor-container">
@@ -177,11 +177,29 @@ onUnmounted(() => {
 
 .header {
   text-align: center;
-  font-weight: bold;
   color: var(--color-heading);
 }
 
+.file-title {
+  font-size: 1.5rem;
+  font-weight: var(--font-weight-bold);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-title.empty {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  opacity: 0.45;
+}
+
 .editor-container {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -191,23 +209,43 @@ onUnmounted(() => {
   display: flex;
   justify-content: center;
   gap: 2rem;
-  margin-top: 1rem;
+  margin-top: 1.25rem;
 }
 
 button {
   padding: 10px 24px;
   cursor: pointer;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-background-soft);
   color: var(--color-text);
-  font-weight: bold;
+  font-weight: var(--font-weight-medium);
+  transition: background-color var(--transition), border-color var(--transition),
+    transform var(--transition), box-shadow var(--transition);
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--color-border-hover);
+  transform: translateY(-1px);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 button.primary {
   background-color: var(--color-primary);
   color: white;
   border: none;
+}
+
+button.primary:hover:not(:disabled) {
+  background-color: var(--color-primary-hover);
 }
 
 button:disabled {

--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -393,7 +393,7 @@ onUnmounted(() => {
 
 .title-bar span {
   color: var(--color-heading);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
@@ -411,6 +411,23 @@ onUnmounted(() => {
     cursor: pointer;
     font-size: 1.2rem;
     color: var(--color-text);
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition), color var(--transition);
+}
+
+.icon-btn:hover {
+    background-color: var(--color-background-mute);
+    color: var(--color-primary);
+}
+
+.icon-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
 }
 
 .root-menu-trigger {
@@ -421,16 +438,22 @@ onUnmounted(() => {
     position: absolute;
     right: 0;
     top: 100%;
+    margin-top: var(--space-1);
     background: var(--color-background);
     border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
     min-width: 150px;
-    box-shadow: var(--shadow-normal);
+    box-shadow: var(--shadow-strong);
     z-index: 200;
+    overflow: hidden;
+    padding: var(--space-1);
 }
 
 .root-menu div {
     padding: 10px;
     cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition);
 }
 .root-menu div:hover {
     background-color: var(--color-background-mute);

--- a/src/components/TreeItem.vue
+++ b/src/components/TreeItem.vue
@@ -175,7 +175,7 @@ li {
   padding: 0 8px;
   cursor: pointer;
   position: relative;
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   visibility: hidden;
 }
 
@@ -188,19 +188,23 @@ li {
   position: absolute;
   right: 0;
   top: 100%;
+  margin-top: var(--space-1);
   background: var(--color-background);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-strong);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   z-index: 100;
   min-width: 120px;
   display: flex;
   flex-direction: column;
+  padding: var(--space-1);
 }
 
 .context-menu div {
   padding: 8px 12px;
   cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition);
 }
 
 .context-menu div:hover {


### PR DESCRIPTION
Introduce a consistent design token layer and apply it across all components. No structural, palette, or dark-theme changes.

Tokens (base.css):
- Radius scale: --radius-sm/md/lg/pill (6/10/14/999px)
- Spacing scale: --space-1..6 (4..32px)
- Unified --transition (160ms ease), --transition-theme (300ms)
- Weight tokens: --font-weight-medium (600), --font-weight-bold (700)
- Focus ring: --focus-ring (soft box-shadow ring, accessible)
- Layered shadows replacing the single flat drop-shadow; dark-theme shadow opacity tuned separately

Components:
- Buttons: weight 600, consistent radius, translateY(-1px) hover lift, :active press, :focus-visible rings throughout
- Inputs / select / textarea: focus ring via box-shadow, hover border
- Headings: explicit bold weight (were inheriting the * { normal } reset)
- Editor (MarkdownEditor): Courier New replaced with modern system-mono stack; flex-based height replacing fixed 80vh so the page never overflows; box-shadow card elevation; combined card+focus shadow on focus; resize: none (was fighting flex layout)
- Sidebar (Tree/TreeItem): icon buttons get hit area + hover/focus feedback; root and context menus get radius, padding, softer shadows
- ModelSelector: select hover border + focus ring

App layout:
- Main pane background shifted to --color-background (recessed canvas) so the editor card reads as raised above it
- Collapsible sidebar: toggle button (« / ☰) pinned top-left, slides the panel via negative margin (contents don't squish), state persisted to localStorage, aria-label + aria-expanded for accessibility

Text component:
- File title: 1.5rem bold with -0.01em tracking; truncates with ellipsis on long filenames
- "No file selected" placeholder: muted (medium weight, 0.45 opacity) so the empty state reads as distinct from an active title